### PR TITLE
`New release` | Merge `Version 0.2.0` into main.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    -
+    name: Install cargo-get
+    run: cargo install cargo-get
     - 
-      name: Publish to Crates.io
-      run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
+      name: Publish to Crates.io if the local version is higher than the latest Crates.io version
+      run: crates_vers=$(curl https://raw.githubusercontent.com/rust-lang/crates.io-index/master/js/on/json_keyquotes_convert | jq -s | jq -r ".[-1].vers"); curr_vers=$(cargo get version); if [[ "$crates_vers" < "$curr_vers" ]]; then cargo publish --token ${CARGO_REGISTRY_TOKEN}; else echo "Version is already up-to-date."; fi
       env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }} 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     -
-    name: Install cargo-get
-    run: cargo install cargo-get
-    - 
+      name: Install cargo-get
+      run: cargo install cargo-get
+    -
       name: Publish to Crates.io if the local version is higher than the latest Crates.io version
       run: crates_vers=$(curl https://raw.githubusercontent.com/rust-lang/crates.io-index/master/js/on/json_keyquotes_convert | jq -s | jq -r ".[-1].vers"); curr_vers=$(cargo get version); if [[ "$crates_vers" < "$curr_vers" ]]; then cargo publish --token ${CARGO_REGISTRY_TOKEN}; else echo "Version is already up-to-date."; fi
       env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }} 
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+- Nothing yet.
+
+## [0.2.0] - 2022-10-28
+### Added
+- Added documentation to [docs.rs](https://docs.rs/json_keyquotes_convert).
+- Added more tests to improve the coverage.
+- Use Rust modules to divide the functionality.
+- Made the core functions public.
+- Applied the Builder Pattern for `JsonKeyQuoteConverter` (usage of this is now recommended over calling the core functions).
+
+### Changed
+- Greatly improved the README of the crate.
+- Lots of improvements and bugfixes for the core functions.
+- Improved the release pipeline to only push a new version to Crates.io when it is newer than the current published version.
+
+## [0.1.1] - 2022-09-26
+### Changed
+- Increased the version number.
+
+## [0.1.0] - 2022-09-26
+### Added
+- Added the `json_convert_without_to_with_keyquotes` function to convert a file from JSON without keyquotes to JSON with keyquotes.
+- Added the `json_convert_with_to_without_keyquotes` function to convert a file from JSON with keyquotes to JSON without keyquotes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
 name = "json_keyquotes_convert"
 description = "A Rust library crate to convert JSON from and to JSON without key-quotes."
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
-license-file = "LICENSE"
 repository = "https://https://github.com/Andreas02-dev/json_keyquotes_convert_rs/"
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,92 @@
-### Status
-[![Tests](https://github.com/Andreas02-dev/json_keyquotes_convert_rs/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/Andreas02-dev/json_keyquotes_convert_rs/actions/workflows/tests.yml)
-[![Crates.io](https://github.com/Andreas02-dev/json_keyquotes_convert_rs/actions/workflows/publish.yml/badge.svg?branch=main)](https://github.com/Andreas02-dev/json_keyquotes_convert_rs/actions/workflows/publish.yml)
+### Crate status
+[![crates.io](https://img.shields.io/crates/v/json_keyquotes_convert.svg)](https://crates.io/crates/json_keyquotes_convert)
+[![docs.rs](https://img.shields.io/docsrs/json_keyquotes_convert)](https://docs.rs/json_keyquotes_convert)
+[![License](https://img.shields.io/crates/l/json_keyquotes_convert.svg)](LICENSE)
+### Pipeline status
+[![Test pipeline](https://github.com/Andreas02-dev/json_keyquotes_convert_rs/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/Andreas02-dev/json_keyquotes_convert_rs/actions/workflows/tests.yml)
+[![Crates.io deployment pipeline](https://github.com/Andreas02-dev/json_keyquotes_convert_rs/actions/workflows/publish.yml/badge.svg?branch=main)](https://github.com/Andreas02-dev/json_keyquotes_convert_rs/actions/workflows/publish.yml)
 
-### Crate information
+### Installation
+```
+cargo add json_keyquotes_convert
+```
 
-* [Crates.io](https://crates.io/crates/json_keyquotes_convert)
-* [Docs.rs](https://docs.rs/json_keyquotes_convert/)
+### Example usage
 
-### Usage
+- For more information, look at the [docs](https://docs.rs/json_keyquotes_convert).
 
-- `json_convert_with_to_without_keyquotes` converts a file from JSON with keyquotes and (\t and \n) escape characters to JSON without keyquotes and (\t and \n) escape characters.
-- `json_convert_without_to_with_keyquotes` converts a file from JSON without keyquotes and (\t and \n) escape characters to JSON with keyquotes and (\t and \n) escape characters.
+##### Using the builder pattern (recommended):
+```rust
+use json_keyquotes_convert::{JsonKeyQuoteConverter, Quotes};
 
-### Important
+let json = JsonKeyQuoteConverter::new("{key: \"va\nl\"}", Quotes::default())
+	.add_key_quotes().json_escape_ctrlchars().json();
 
-Please note that this crate does not check whether the output is valid JSON. The functionality of this crate is based on Regular Expressions and uses the [regex](https://crates.io/crates/regex) crate.
+// JSON string will now be: {\"key\": \"va\\nl\"}
+// Raw JSON will now be: {"key": "va\nl"}
+```
+
+##### Using functions:
+```rust
+use json_keyquotes_convert::{json_key_quote_utils, Quotes};
+
+let json_added = json_key_quote_utils::json_add_key_quotes("{key: \"va\nl\"}", Quotes::default());
+let json_escaped = json_key_quote_utils::json_escape_ctrlchars(&json_added);
+
+// JSON string will now be: {\"key\": \"va\\nl\"}
+// Raw JSON will now be: {"key": "va\nl"}
+```
+
+### Important information
+
+#### Crate support legend
+
+|       Great        |         Good        |  Unsupported  |
+| :----------------: | :-----------------: | :-----------: |
+| :heavy_check_mark: |  :white_check_mark: |     :x:       |
+|   Automatically    |     Configurable    |  Unsupported  |
+
+#### Crate support
+** Any unlisted features might be unsupported. **
+  - Adding quotes around JSON keys:
+  	- Double-quotes: :heavy_check_mark: (default)
+	- Single-quotes: :white_check_mark:
+  - Removing quotes around JSON keys:
+	- Double-quotes: :heavy_check_mark:
+	- Single-quotes: :heavy_check_mark:
+  - Supported quotes around JSON string values:
+	- Double-quotes: :heavy_check_mark:
+	- Single-quotes: :heavy_check_mark:
+  - Supports control character escaping in JSON keys:
+	- Newline (\n): :heavy_check_mark: :white_check_mark:
+	- Tab (\t): :heavy_check_mark: :white_check_mark:
+	- Note: These characters could be misinterpreted as not belonging to the key. It is therefore not recommended to start or end a JSON key with these characters.
+  - Supports control character unescaping in JSON keys:
+	- Newline (\n): :heavy_check_mark: :white_check_mark:
+	- Tab (\t): :heavy_check_mark: :white_check_mark:
+	- Note: These characters could be misinterpreted as not belonging to the key. It is therefore not recommended to start or end a JSON key with these characters.
+  - Supports control character escaping in JSON string values:
+	- Newline (\n): :heavy_check_mark: :white_check_mark:
+	- Tab (\t): :heavy_check_mark: :white_check_mark:
+  - Supports control character unescaping in JSON string values:
+	- Newline (\n): :heavy_check_mark: :white_check_mark:
+	- Tab (\t): :heavy_check_mark: :white_check_mark:
+  - Supported :heavy_check_mark: characters in JSON keys:
+	- [A-Z] [a-z] [0-9] \` ~ ! @ # $ % € ^ & * ( ) - _ = + \ | ; " ' . < > / ? \r \n \t \f \v `<U+0020>(Space)`
+	- Note: ' and " and their escaped variants could be misinterpreted as keyquotes when used as the last character in a JSON key. It is therefore not recommended to start or end a JSON key with these characters.
+  - Supported :heavy_check_mark: characters in JSON values:
+    - [A-Z] [a-z] [0-9] \` ~ ! @ # $ % € ^ & * ( ) - _ = + \ | : ; " ' . < > / ? \r \n \t \f \v `<U+0020>(Space)`
+	
+#### Please note that this crate does not check whether the output is valid JSON. The functionality of this crate is based on Regular Expressions and uses the [regex](https://crates.io/crates/regex) crate.
+
+### Changelog
+
+- See the [changelog](./CHANGELOG.md).
+
+### Contributing
+
+- All contributions are welcome. I will do my best to reply to all questions and PR's.
+- Please do note that all contributions made to this crate will be made available using the current license (MIT license).
 
 ### Third party licenses
 

--- a/src/json_key_quote_utils.rs
+++ b/src/json_key_quote_utils.rs
@@ -1,0 +1,627 @@
+//! Core functions used for the JSON conversions.
+//! 
+//! Contains the core functionality of this crate.
+
+use std::{path::Path};
+
+use regex::Regex;
+
+use crate::{load_write_utils, Quotes};
+
+const SUPPORTED_KEY_CHARS_REGEX_STR: &str = r#"A-Za-z0-9`~!@#$%€^&*()\-_=+\\|;"'.<>/?\s"#;
+
+
+/// Convenience method for chained [load_write_utils::load_json],
+/// [json_remove_key_quotes], [json_unescape_ctrlchars]
+///  and [load_write_utils::write_json] function calls.
+/// 
+/// # Arguments
+/// 
+/// * `path` - The file path.
+/// 
+/// # Examples
+/// 
+/// ```rust,ignore
+/// use std::path::Path;
+/// use json_keyquotes_convert::{json_key_quote_utils};
+/// 
+/// let path = Path::new("./test_resources/Test_with_keyquotes.json");
+/// json_key_quote_utils::json_convert_with_to_without_keyquotes(path);
+/// ```
+pub fn json_convert_with_to_without_keyquotes(path: &Path) {
+
+    let json = match load_write_utils::load_json(path) {
+        Ok(val) => val,
+        Err(err) => {
+            eprintln!("{}", err);
+            return;
+        }
+    };
+
+    let unquoted_json = json_remove_key_quotes(&json);
+
+    match load_write_utils::write_json(path, &json_unescape_ctrlchars(&unquoted_json)) {
+        Ok(()) => (),
+        Err(err) => {
+            eprintln!("{}", err);
+            return;
+        }
+    }
+}
+
+/// Convenience method for chained [load_write_utils::load_json], [json_add_key_quotes]
+/// ,[json_escape_ctrlchars] and [load_write_utils::write_json] calls.
+/// 
+/// # Arguments
+/// 
+/// * `path` - The file path.
+/// * `quote_type` - Whether the JSON keys should be single- or double-quoted.
+/// 
+/// # Examples
+/// 
+/// ```rust,ignore
+/// use std::path::Path;
+/// use json_keyquotes_convert::{json_keyquote_utils, Quotes};
+/// 
+/// let path = Path::new("./test_resources/Test_without_keyquotes.json")
+/// json_keyquote_utils::json_convert_without_to_with_keyquotes(path, Quotes::default());
+/// ```
+pub fn json_convert_without_to_with_keyquotes(path: &Path, quote_type: Quotes) {
+
+    let json = match load_write_utils::load_json(path) {
+        Ok(val) => val,
+        Err(err) => {
+            eprintln!("{}", err);
+            return;
+        }
+    };
+
+    let keyquoted_json = json_add_key_quotes(&json, quote_type);
+
+    match load_write_utils::write_json(path, &json_escape_ctrlchars(&keyquoted_json)) {
+        Ok(()) => (),
+        Err(err) => {
+            eprintln!("{}", err);
+            return;
+        }
+    }
+}
+
+/// Adds key-quotes to the JSON string.
+/// 
+/// # Arguments
+/// 
+/// * `json` - The JSON string.
+/// * `quote_type` - Whether the JSON keys should be single- or double-quoted.
+/// 
+/// # Examples
+/// 
+/// ```
+/// use json_keyquotes_convert::{json_key_quote_utils, Quotes};
+/// 
+/// let json_added = json_key_quote_utils::json_add_key_quotes("{key: \"val\"}", Quotes::default());
+/// assert_eq!(json_added, "{\"key\": \"val\"}");
+/// 
+/// let json_already_existing = json_key_quote_utils::json_add_key_quotes("{\"key\": \"val\"}", Quotes::default());
+/// assert_eq!(json_already_existing, "{\"key\": \"val\"}");
+/// ```
+pub fn json_add_key_quotes(json: &str, quote_type: Quotes) -> String {
+    
+    // Add quotes around all string keys (single-quoted):
+    // `/` == `\/` in Regex101
+    let single_quoted_string_val_regex = Regex::new(&(r#"(?P<prevchar_key>[^"'][\s]*)(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])(?P<val>:\s*?'[\s\S]*?')"#)).unwrap();
+    let json_single_quoted_string_passed = single_quoted_string_val_regex.replace_all(json, "$prevchar_key".to_string() + quote_type.as_str() + "$key" + quote_type.as_str() + "$val");
+
+    // Add quotes around all string keys (double-quoted):
+    // `/` == `\/` in Regex101
+    let double_quoted_string_val_regex = Regex::new(&(r#"(?P<prevchar_key>[^"'][\s]*)(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])(?P<val>:\s*?"[\s\S]*?")"#)).unwrap();
+    let json_double_quoted_string_passed = double_quoted_string_val_regex.replace_all(&json_single_quoted_string_passed, "$prevchar_key".to_string() + quote_type.as_str() + "$key" + quote_type.as_str() + "$val");
+
+    // Add quotes around all object keys:
+    // `/` == `\/` in Regex101
+    let object_val_regex = Regex::new(&(r#"(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])(?P<val>:\s*?[{\[])"#)).unwrap();
+    let json_object_passed = object_val_regex.replace_all(&json_double_quoted_string_passed, quote_type.as_str().to_string() + "$key" + quote_type.as_str() + "$val");
+
+    // Add quotes around all number keys:
+    // `/` == `\/` in Regex101
+    let number_val_regex = Regex::new(&(r#"(?P<before>[\[,{]\s*?)(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])(?P<after>:\s*?[\d\-\.])"#)).unwrap();
+    let json_number_passed = number_val_regex.replace_all(&json_object_passed, "$before".to_string() + quote_type.as_str() + "$key" + quote_type.as_str() + "$after");
+
+    // Add quotes around all `null`, and `boolean` keys:
+    // `/` == `\/` in Regex101
+    let null_bools_val_regex = Regex::new(&(r#"(?P<before>[\[,{]\s*?)(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])(?P<after>:\s*?(?:null|true|false))"#)).unwrap();
+    let json_null_bools_passed = null_bools_val_regex.replace_all(&json_number_passed, "$before".to_string() + quote_type.as_str() + "$key" + quote_type.as_str() + "$after");
+
+    return json_null_bools_passed.to_string();
+}
+
+/// Removes key-quotes from the JSON string.
+/// 
+/// # Arguments
+/// 
+/// * `json` - The JSON string.
+/// 
+/// # Examples
+/// 
+/// ```
+/// use json_keyquotes_convert::{json_key_quote_utils, Quotes};
+/// 
+/// let json_removed = json_key_quote_utils::json_remove_key_quotes("{\"key\": \"val\"}");
+/// assert_eq!(json_removed, "{key: \"val\"}");
+/// 
+/// let json_already_removed = json_key_quote_utils::json_remove_key_quotes("{key: \"val\"}");
+/// assert_eq!(json_already_removed, "{key: \"val\"}");
+/// ```
+pub fn json_remove_key_quotes(json: &str) -> String {
+
+    // Remove the quotes from the keys (single-quoted):
+    // `/` == `\/` in Regex101
+    let single_quotes_regex = Regex::new(&(r#"(?P<before>[{\[,][\s]*)'(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?)'(?P<after>\s*?:)"#)).unwrap();
+    let json_single_quotes_passed = single_quotes_regex.replace_all(json, "$before$key$after");
+
+    // Remove the quotes from the keys (double-quoted):
+    // `/` == `\/` in Regex101
+    let double_quotes_regex = Regex::new(&(r#"(?P<before>[{\[,][\s]*)"(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?)"(?P<after>\s*?:)"#)).unwrap();
+    let json_double_quotes_passed = double_quotes_regex.replace_all(&json_single_quotes_passed, "$before$key$after");
+
+    return json_double_quotes_passed.to_string();
+}
+
+/// Escape ctrl-characters from the JSON string values
+/// and the JSON keys with keyquotes.
+/// 
+/// This method will escape `newlines` and `tabs` in the JSON string values
+/// and in the JSON keys with keyquotes.
+/// 
+/// # Arguments
+/// 
+/// * `json` - The JSON string.
+/// 
+/// # Examples
+/// 
+/// ```
+/// use json_keyquotes_convert::{json_key_quote_utils};
+/// 
+/// let json_escaped = json_key_quote_utils::json_escape_ctrlchars(r#"{"ke
+/// y": "va
+/// l"}"#);
+/// assert_eq!(json_escaped, r#"{"ke\ny": "va\nl"}"#);
+/// 
+/// let json_already_escaped = json_key_quote_utils::json_escape_ctrlchars(r#"{"ke\ny": "va\nl"}"#);
+/// assert_eq!(json_already_escaped, r#"{"ke\ny": "va\nl"}"#);
+/// ```
+pub fn json_escape_ctrlchars(json: &str) -> String {
+
+    // Replace all control characters with their escaped variants:
+
+    let mut new_json = json.to_owned();
+
+    // Two iterations are needed for the tab escaping:
+
+    for _n in 0..2 {
+        // For all single-quoted string keys with single-quoted values:
+        let singlequoted_string_key_regex = Regex::new(&(r#"(?P<prevchar_key>[^"'][\s]*)'(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])'(?P<val>\s*?:\s*?'[\s\S]*?')"#)).unwrap();
+        for cap in singlequoted_string_key_regex.captures_iter(&new_json.clone()) {
+            let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\n", "\\n"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\t", "\\t").replace("\t", "\\t"), 1);
+        }
+
+        // For all double-quoted string keys with single-quoted values:
+        let singlequoted_string_key_regex = Regex::new(&(r#"(?P<prevchar_key>[^"'][\s]*)"(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])"(?P<val>\s*?:\s*?'[\s\S]*?')"#)).unwrap();
+        for cap in singlequoted_string_key_regex.captures_iter(&new_json.clone()) {
+            let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\n", "\\n"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\t", "\\t").replace("\t", "\\t"), 1);
+        }
+
+        // For all single-quoted string keys with double-quoted values:
+        let doublequoted_string_key_regex = Regex::new(&(r#"(?P<prevchar_key>[^"'][\s]*)'(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])'(?P<val>\s*?:\s*?"[\s\S]*?")"#)).unwrap();
+        for cap in doublequoted_string_key_regex.captures_iter(&new_json.clone()) {
+            let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\n", "\\n"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\t", "\\t").replace("\t", "\\t"), 1);
+        }
+
+        // For all double-quoted string keys with double-quoted values:
+        let doublequoted_string_key_regex = Regex::new(&(r#"(?P<prevchar_key>[^"'][\s]*)"(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])"(?P<val>\s*?:\s*?"[\s\S]*?")"#)).unwrap();
+        for cap in doublequoted_string_key_regex.captures_iter(&new_json.clone()) {
+            let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\n", "\\n"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\t", "\\t").replace("\t", "\\t"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\t", "\\t").replace("\t", "\\t"), 1);
+        }
+
+        // For all single-quoted object keys:
+        let object_key_regex = Regex::new(&(r#"'(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])'(?P<val>\s*?:\s*?[{\[])"#)).unwrap();
+        for cap in object_key_regex.captures_iter(&new_json.clone()) {
+            let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\n", "\\n"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\t", "\\t").replace("\t", "\\t"), 1);
+        }
+
+        // For all double-quoted object keys:
+        let object_key_regex = Regex::new(&(r#""(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])"(?P<val>\s*?:\s*?[{\[])"#)).unwrap();
+        for cap in object_key_regex.captures_iter(&new_json.clone()) {
+            let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\n", "\\n"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\t", "\\t").replace("\t", "\\t"), 1);
+        }
+
+        // For all single-quoted number keys:
+        let number_key_regex = Regex::new(&(r#"(?P<before>[\[,{]\s*?)'(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])'(?P<after>\s*?:\s*?[\d\-\.])"#)).unwrap();
+        for cap in number_key_regex.captures_iter(&new_json.clone()) {
+            let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\n", "\\n"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\t", "\\t").replace("\t", "\\t"), 1);
+        }
+
+        // For all double-quoted number keys:
+        let number_key_regex = Regex::new(&(r#"(?P<before>[\[,{]\s*?)"(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])"(?P<after>\s*?:\s*?[\d\-\.])"#)).unwrap();
+        for cap in number_key_regex.captures_iter(&new_json.clone()) {
+            let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\n", "\\n"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\t", "\\t").replace("\t", "\\t"), 1);
+        }
+
+        // For all single-quoted null and boolean keys:
+        let null_boolean_key_regex = Regex::new(&(r#"(?P<before>[\[,{]\s*?)'(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])'(?P<after>\s*?:\s*?(?:null|true|false))"#)).unwrap();
+        for cap in null_boolean_key_regex.captures_iter(&new_json.clone()) {
+            let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\n", "\\n"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\t", "\\t").replace("\t", "\\t"), 1);
+        }
+
+        // For all double-quoted null and boolean keys:
+        let null_boolean_key_regex = Regex::new(&(r#"(?P<before>[\[,{]\s*?)"(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])"(?P<after>\s*?:\s*?(?:null|true|false))"#)).unwrap();
+        for cap in null_boolean_key_regex.captures_iter(&new_json.clone()) {
+            let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\n", "\\n"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\t", "\\t").replace("\t", "\\t"), 1);
+        }
+
+        // For all single-quoted string values:
+        let singlequoted_string_value_regex = Regex::new(r#":[\s]*?'((?:[^'\\]|\\.)*)'"#).unwrap();
+        for cap in singlequoted_string_value_regex.captures_iter(&new_json.clone()) {
+            new_json = new_json.replacen(&cap[1], &cap[1].replace("\n", "\\n"), 1);
+            new_json = new_json.replacen(&cap[1], &cap[1].replace("\t", "\\t"), 1);
+        }
+
+        // For all double-quoted string values:
+        let doublequoted_string_value_regex = Regex::new(r#":[\s]*?"((?:[^"\\]|\\.)*)""#).unwrap();
+        for cap in doublequoted_string_value_regex.captures_iter(&new_json.clone()) {
+            new_json = new_json.replacen(&cap[1], &cap[1].replace("\n", "\\n"), 1);
+            new_json = new_json.replacen(&cap[1], &cap[1].replace("\t", "\\t"), 1);
+        }
+    }
+
+    new_json
+}
+
+/// Unescape ctrl-characters from the JSON string values
+/// and the JSON keys without keyquotes.
+/// 
+/// This method will unescape `newlines` and `tabs` in the JSON string values
+/// and in the JSON keys without keyquotes.
+/// 
+/// # Arguments
+/// 
+/// * `json` - The JSON string.
+/// 
+/// # Examples
+/// 
+/// ```
+/// use json_keyquotes_convert::{json_key_quote_utils};
+/// 
+/// let json_unescaped = json_key_quote_utils::json_unescape_ctrlchars(r#"{ke\ny: "va\nl"}"#);
+/// assert_eq!(json_unescaped, r#"{ke
+/// y: "va
+/// l"}"#);
+/// 
+/// let json_already_unescaped = json_key_quote_utils::json_unescape_ctrlchars(&json_unescaped);
+/// assert_eq!(json_already_unescaped, r#"{ke
+/// y: "va
+/// l"}"#);
+/// ```
+pub fn json_unescape_ctrlchars(json: &str) -> String {
+
+    // Replace all escaped control characters with their unescaped variants:
+
+    let mut new_json = json.to_owned();
+
+    // Two iterations are needed for the tab unescaping:
+
+    for _n in 0..2 {
+
+        // For all single-quoted string keys:
+        let singlequoted_string_key_regex = Regex::new(&(r#"(?P<prevchar_key>[^"'][\s]*)(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])(?P<val>\s*?:\s*?'[\s\S]*?')"#)).unwrap();
+        for cap in singlequoted_string_key_regex.captures_iter(&new_json.clone()) {
+            let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\\n", "\n"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\\t", "\t"), 1);
+        }
+
+        // For all double-quoted string keys:
+        let doublequoted_string_key_regex = Regex::new(&(r#"(?P<prevchar_key>[^"'][\s]*)(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])(?P<val>\s*?:\s*?"[\s\S]*?")"#)).unwrap();
+        for cap in doublequoted_string_key_regex.captures_iter(&new_json.clone()) {
+            let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\\n", "\n"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\\t", "\t"), 1);
+        }
+
+        // For all object keys:
+        let object_key_regex = Regex::new(&(r#"(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])(?P<val>\s*?:\s*?[{\[])"#)).unwrap();
+        for cap in object_key_regex.captures_iter(&new_json.clone()) {
+            let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\\n", "\n"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\\t", "\t"), 1);
+        }
+
+        // For all number keys:
+        let number_key_regex = Regex::new(&(r#"(?P<before>[\[,{]\s*?)(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])(?P<after>\s*?:\s*?[\d\-\.])"#)).unwrap();
+        for cap in number_key_regex.captures_iter(&new_json.clone()) {
+            let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\\n", "\n"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\\t", "\t"), 1);
+        }
+
+        // For all null and boolean keys:
+        let null_boolean_key_regex = Regex::new(&(r#"(?P<before>[\[,{]\s*?)(?P<key>["#.to_string() + SUPPORTED_KEY_CHARS_REGEX_STR + r#"]*?[^"'])(?P<after>\s*?:\s*?(?:null|true|false))"#)).unwrap();
+        for cap in null_boolean_key_regex.captures_iter(&new_json.clone()) {
+            let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\\n", "\n"), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\\t", "\t"), 1);
+        }
+
+        // For all single-quoted string values:
+        let singlequoted_string_value_regex = Regex::new(r#":[\s]*?'((?:[^'\\]|\\.)*)'"#).unwrap();
+        for cap in singlequoted_string_value_regex.captures_iter(&new_json.clone()) {
+            new_json = new_json.replacen(&cap[1], &cap[1].replace("\\n", "\n"), 1);
+            new_json = new_json.replacen(&cap[1], &cap[1].replace("\\t", "\t"), 1);
+        }
+
+        // For all double-quoted string values:
+        let doublequoted_string_value_regex = Regex::new(r#":[\s]*?"((?:[^"\\]|\\.)*)""#).unwrap();
+        for cap in doublequoted_string_value_regex.captures_iter(&new_json.clone()) {
+            new_json = new_json.replacen(&cap[1], &cap[1].replace("\\n", "\n"), 1);
+            new_json = new_json.replacen(&cap[1], &cap[1].replace("\\t", "\t"), 1);
+        }
+    }
+    
+    new_json
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{path::Path};
+    use crate::{json_key_quote_utils, load_write_utils, Quotes};
+
+    const SUPPORTED_KEY_CHARS: &str = r#"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789`~!@#$%€^&*()-_=+\|;"'.<>/?"#;
+    const SUPPORTED_VALUE_CHARS: &str = r#"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789`~!@#$%€^&*()-_=+\|:;"'.<>/?"#;
+
+    #[test]
+    fn test_json_convert_without_to_with_keyquotes() {
+        let path = Path::new("./tmp_without_keyquotes");
+        std::fs::copy("./test_resources/Test_without_keyquotes.json", "./tmp_without_keyquotes").unwrap();
+        json_key_quote_utils::json_convert_without_to_with_keyquotes(path, crate::Quotes::DoubleQuote);
+        let converted_file_contents = load_write_utils::load_json(path).unwrap();
+        let expected_file_contents = load_write_utils::load_json(Path::new("./test_resources/Test_with_keyquotes.json")).unwrap();
+        assert!(converted_file_contents == expected_file_contents);
+        std::fs::remove_file("./tmp_without_keyquotes").unwrap();
+    }
+
+    #[test]
+    fn test_json_convert_with_to_without_keyquotes() {
+        let path = Path::new("./tmp_with_keyquotes");
+        std::fs::copy("./test_resources/Test_with_keyquotes.json", "./tmp_with_keyquotes").unwrap();
+        json_key_quote_utils::json_convert_with_to_without_keyquotes(path);
+        let converted_file_contents = load_write_utils::load_json(path).unwrap();
+        let expected_file_contents = load_write_utils::load_json(Path::new("./test_resources/Test_without_keyquotes.json")).unwrap();
+        assert!(converted_file_contents == expected_file_contents);
+        std::fs::remove_file("./tmp_with_keyquotes").unwrap();
+    }
+
+    #[test]
+    fn test_json_add_key_quotes_single_quote_add_supported_characters() {
+        let supported_key_chars = SUPPORTED_KEY_CHARS.replacen(r#"'"#, r#"\'"#, 1);
+        let supported_value_chars = SUPPORTED_VALUE_CHARS.replacen(r#"'"#, r#"\'"#, 1);
+
+        let json = r#"{"#.to_string() + &supported_key_chars + r#": '"# + &supported_value_chars + r#"'}"#;
+        let expected = r#"{'"#.to_string() + &supported_key_chars + r#"': '"# + &supported_value_chars + r#"'}"#;
+
+        let actual = json_key_quote_utils::json_add_key_quotes(&json, Quotes::SingleQuote);
+        let actual_second_pass = json_key_quote_utils::json_add_key_quotes(&actual, Quotes::SingleQuote);
+
+        assert_eq!(expected, actual);
+        assert_eq!(expected, actual_second_pass);
+    }
+
+    #[test]
+    fn test_json_add_key_quotes_double_quote_add_supported_characters() {
+        let supported_key_chars = SUPPORTED_KEY_CHARS.replacen(r#"""#, r#"\""#, 1);
+        let supported_value_chars = SUPPORTED_VALUE_CHARS.replacen(r#"""#, r#"\""#, 1);
+
+        let json = r#"{"#.to_string() + &supported_key_chars + r#": ""# + &supported_value_chars +r#""}"#;
+        let expected = r#"{""#.to_string() + &supported_key_chars + r#"": ""# + &supported_value_chars + r#""}"#;
+
+        let actual = json_key_quote_utils::json_add_key_quotes(&json, Quotes::DoubleQuote);
+        let actual_second_pass = json_key_quote_utils::json_add_key_quotes(&actual, Quotes::DoubleQuote);
+
+        assert_eq!(expected, actual);
+        assert_eq!(expected, actual_second_pass);
+    }
+
+    #[test]
+    fn test_json_remove_key_quotes_single_quoted_supported_characters() {
+        let supported_key_chars = SUPPORTED_KEY_CHARS.replacen(r#"'"#, r#"\'"#, 1);
+        let supported_value_chars = SUPPORTED_VALUE_CHARS.replacen(r#"'"#, r#"\'"#, 1);
+
+        let json = r#"{'"#.to_string() + &supported_key_chars + r#"': ""# + &supported_value_chars + r#""}"#;
+        let expected = r#"{"#.to_string() + &supported_key_chars + r#": ""# + &supported_value_chars + r#""}"#;
+
+        let actual = json_key_quote_utils::json_remove_key_quotes(&json);
+        let actual_second_pass = json_key_quote_utils::json_remove_key_quotes(&actual);
+
+        assert_eq!(expected, actual);
+        assert_eq!(expected, actual_second_pass);
+    }
+
+    #[test]
+    fn test_json_remove_key_quotes_double_quoted_supported_characters() {
+        let supported_key_chars = SUPPORTED_KEY_CHARS.replacen(r#"""#, r#"\""#, 1);
+        let supported_value_chars = SUPPORTED_VALUE_CHARS.replacen(r#"""#, r#"\""#, 1);
+
+        let json = r#"{""#.to_string() + &supported_key_chars + r#"": ""# + &supported_value_chars + r#""}"#;
+        let expected = r#"{"#.to_string() + &supported_key_chars + r#": ""# + &supported_value_chars + r#""}"#;
+
+        let actual = json_key_quote_utils::json_remove_key_quotes(&json);
+        let actual_second_pass = json_key_quote_utils::json_remove_key_quotes(&actual);
+
+        assert_eq!(expected, actual);
+        assert_eq!(expected, actual_second_pass);
+    }
+
+    #[test]
+    fn test_json_escape_ctrlchars_single_quoted_supported_characters() {
+        let supported_key_chars = SUPPORTED_KEY_CHARS.replacen(r#"'"#, r#"\'"#, 1);
+        let supported_value_chars = SUPPORTED_VALUE_CHARS.replacen(r#"'"#, r#"\'"#, 1);
+
+        let key = supported_key_chars.replacen("A", r#"A
+"#, 1).replacen("B", r#"B	"#, 1);
+        let value = supported_value_chars.replacen("A", r#"A
+"#, 1).replacen("B", r#"B	"#, 1);
+
+        let expected_key = supported_key_chars.replacen("A", r#"A\n"#, 1)
+            .replacen("B", r#"B\t"#, 1);
+        let expected_value = supported_value_chars.replacen("A", r#"A\n"#, 1)
+        .replacen("B", r#"B\t"#, 1);
+
+        let json = r#"{'"#.to_string() + &key + r#"': '"# + &value + r#"'}"#;
+        let expected = r#"{'"#.to_string() + &expected_key + r#"': '"# + &expected_value + r#"'}"#;
+
+        let actual = json_key_quote_utils::json_escape_ctrlchars(&json);
+        let actual_second_pass = json_key_quote_utils::json_escape_ctrlchars(&actual);
+
+        assert_eq!(expected, actual);
+        assert_eq!(expected, actual_second_pass);
+    }
+
+    #[test]
+    fn test_json_escape_ctrlchars_double_quoted_supported_characters() {
+        let supported_key_chars = SUPPORTED_KEY_CHARS.replacen(r#"""#, r#"\""#, 1);
+        let supported_value_chars = SUPPORTED_VALUE_CHARS.replacen(r#"""#, r#"\""#, 1);
+
+        let key = supported_key_chars.replacen("A", r#"A
+"#, 1).replacen("B", r#"B	"#, 1);
+        let value = supported_value_chars.replacen("A", r#"A
+"#, 1).replacen("B", r#"B	"#, 1);
+
+        let expected_key = supported_key_chars.replacen("A", r#"A\n"#, 1)
+            .replacen("B", r#"B\t"#, 1);
+        let expected_value = supported_value_chars.replacen("A", r#"A\n"#, 1)
+        .replacen("B", r#"B\t"#, 1);
+
+        let json = r#"{""#.to_string() + &key + r#"": ""# + &value + r#""}"#;
+        let expected = r#"{""#.to_string() + &expected_key + r#"": ""# + &expected_value + r#""}"#;
+
+        let actual = json_key_quote_utils::json_escape_ctrlchars(&json);
+        let actual_second_pass = json_key_quote_utils::json_escape_ctrlchars(&actual);
+
+        assert_eq!(expected, actual);
+        assert_eq!(expected, actual_second_pass);
+    }
+
+    #[test]
+    fn test_json_escape_ctrlchars_unquoted_keys_supported_characters() {
+        let supported_value_chars = SUPPORTED_VALUE_CHARS.replacen(r#"""#, r#"\""#, 1);
+
+        let key = SUPPORTED_KEY_CHARS.replacen("A", r#"A
+"#, 1).replacen("B", r#"B	"#, 1);
+        let value = supported_value_chars.replacen("A", r#"A
+"#, 1).replacen("B", r#"B	"#, 1);
+
+        let expected_value = supported_value_chars.replacen("A", r#"A\n"#, 1)
+        .replacen("B", r#"B\t"#, 1);
+
+        let json = r#"{"#.to_string() + &key + r#": ""# + &value + r#""}"#;
+        let expected = r#"{"#.to_string() + &key + r#": ""# + &expected_value + r#""}"#;
+
+        let actual = json_key_quote_utils::json_escape_ctrlchars(&json);
+        let actual_second_pass = json_key_quote_utils::json_escape_ctrlchars(&actual);
+
+        assert_eq!(expected, actual);
+        assert_eq!(expected, actual_second_pass);
+    }
+
+    #[test]
+    fn test_json_unescape_ctrlchars_single_quoted_supported_characters() {
+        let supported_key_chars = SUPPORTED_KEY_CHARS.replacen(r#"'"#, r#"\'"#, 1);
+        let supported_value_chars = SUPPORTED_VALUE_CHARS.replacen(r#"'"#, r#"\'"#, 1);
+
+        let key = supported_key_chars.replacen("A", r#"A\n"#, 1)
+            .replacen("B", r#"B\t"#, 1);
+        let value = supported_value_chars.replacen("A", r#"A\n"#, 1)
+        .replacen("B", r#"B\t"#, 1);
+
+        let expected_key = supported_key_chars.replacen("A", r#"A
+"#, 1).replacen("B", r#"B	"#, 1);
+        let expected_value = supported_value_chars.replacen("A", r#"A
+"#, 1).replacen("B", r#"B	"#, 1);
+
+        let json = r#"{"#.to_string() + &key + r#": '"# + &value + r#"'}"#;
+        let expected = r#"{"#.to_string() + &expected_key + r#": '"# + &expected_value + r#"'}"#;
+
+        let actual = json_key_quote_utils::json_unescape_ctrlchars(&json);
+        let actual_second_pass = json_key_quote_utils::json_unescape_ctrlchars(&actual);
+
+        assert_eq!(expected, actual);
+        assert_eq!(expected, actual_second_pass);
+    }
+
+    #[test]
+    fn test_json_unescape_ctrlchars_double_quoted_supported_characters() {
+        let supported_key_chars = SUPPORTED_KEY_CHARS.replacen(r#"""#, r#"\""#, 1);
+        let supported_value_chars = SUPPORTED_VALUE_CHARS.replacen(r#"""#, r#"\""#, 1);
+
+        let key = supported_key_chars.replacen("A", r#"A\n"#, 1)
+            .replacen("B", r#"B\t"#, 1);
+        let value = supported_value_chars.replacen("A", r#"A\n"#, 1)
+        .replacen("B", r#"B\t"#, 1);
+
+        let expected_key = supported_key_chars.replacen("A", r#"A
+"#, 1).replacen("B", r#"B	"#, 1);
+        let expected_value = supported_value_chars.replacen("A", r#"A
+"#, 1).replacen("B", r#"B	"#, 1);
+
+        let json = r#"{"#.to_string() + &key + r#": ""# + &value + r#""}"#;
+        let expected = r#"{"#.to_string() + &expected_key + r#": ""# + &expected_value + r#""}"#;
+
+        let actual = json_key_quote_utils::json_unescape_ctrlchars(&json);
+        let actual_second_pass = json_key_quote_utils::json_unescape_ctrlchars(&actual);
+
+        assert_eq!(expected, actual);
+        assert_eq!(expected, actual_second_pass);
+    }
+
+    #[test]
+    fn test_json_unescape_ctrlchars_double_quoted_keys_supported_characters() {
+        let supported_value_chars = SUPPORTED_VALUE_CHARS.replacen(r#"""#, r#"\""#, 1);
+
+        let key = SUPPORTED_KEY_CHARS.replacen("A", r#"A\n"#, 1)
+        .replacen("B", r#"B\t"#, 1);
+        let value = supported_value_chars.replacen("A", r#"A\n"#, 1)
+        .replacen("B", r#"B\t"#, 1);
+
+        let expected_value = supported_value_chars.replacen("A", r#"A
+"#, 1).replacen("B", r#"B	"#, 1);
+
+        let json = r#"{""#.to_string() + &key + r#"": ""# + &value + r#""}"#;
+        let expected = r#"{""#.to_string() + &key + r#"": ""# + &expected_value + r#""}"#;
+
+        let actual = json_key_quote_utils::json_unescape_ctrlchars(&json);
+        let actual_second_pass = json_key_quote_utils::json_unescape_ctrlchars(&actual);
+
+        assert_eq!(expected, actual);
+        assert_eq!(expected, actual_second_pass);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,155 +1,182 @@
-use std::io;
-use std::path::Path;
-use std::fs;
-use regex::Regex;
+//! Documentation for the `json_keyquotes_convert` crate.
+//!
+//! The `json_keyquotes_convert` crate is meant to be used to perform
+//! various transformations to JSON, including but not limited to
+//! adding and removing quotes around the JSON keys.
+//! 
+//! It is recommended to use the [JsonKeyQuoteConverter] builder,
+//! but using the core functions in [json_key_quote_utils] is possible too.
 
-pub fn json_convert_with_to_without_keyquotes(path: &Path) {
+pub mod json_key_quote_utils;
+pub mod load_write_utils;
+
+/// The quotes to use for the JSON keys.
+/// 
+/// This does not affect existing single-quoted or double-quoted keys in JSON.
+/// 
+/// The default value is [Quotes::DoubleQuote].
+#[derive(Clone, Copy)]
+pub enum Quotes {
+    DoubleQuote,
+    SingleQuote
+}
+
+impl Quotes {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Quotes::DoubleQuote => "\"",
+            Quotes::SingleQuote => "'"
+        }
+    }
+}
+
+impl Default for Quotes {
+    fn default() -> Self { Quotes::DoubleQuote }
+}
+
+/// The builder for the JSON conversions.
+pub struct JsonKeyQuoteConverter {
+    json: String,
+    quote_type: Quotes
+}
+
+impl JsonKeyQuoteConverter {
+
+    /// Returns a new [JsonKeyQuoteConverter].
+    /// 
+    /// # Arguments
+    /// 
+    /// * `json` - A JSON string.
+    /// * `quote_type` - Whether the JSON keys should be single- or double-quoted.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use json_keyquotes_convert::{JsonKeyQuoteConverter, Quotes};
+    /// 
+    /// let converter = JsonKeyQuoteConverter::new("{\"key\": \"val\"}", Quotes::default());
+    /// ```
+    pub fn new(json: &str, quote_type: Quotes) -> JsonKeyQuoteConverter {
+        JsonKeyQuoteConverter {
+            json: String::from(json),
+            quote_type: quote_type,
+        }
+    }
+
+    /// Adds key-quotes to the JSON string.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use json_keyquotes_convert::{JsonKeyQuoteConverter, Quotes};
+    /// 
+    /// let json_added = JsonKeyQuoteConverter::new("{key: \"val\"}", Quotes::default())
+    ///     .add_key_quotes().json();
+    /// assert_eq!(json_added, "{\"key\": \"val\"}");
+    /// 
+    /// let json_already_existing = JsonKeyQuoteConverter::new("{\"key\": \"val\"}", Quotes::default())
+    ///     .add_key_quotes().json();
+    /// assert_eq!(json_already_existing, "{\"key\": \"val\"}");
+    /// ```
+    pub fn add_key_quotes(mut self) -> JsonKeyQuoteConverter {
+
+        self.json = json_key_quote_utils::json_add_key_quotes(&self.json, self.quote_type);
         
-    let json = match load_json(path) {
-        Ok(val) => val,
-        Err(err) => {
-            eprintln!("{}", err);
-            return;
-        }
-    };
-
-    let unquoted_json = json_remove_key_quotes(&json);
-
-    match write_json(path, &json_unescape_ctrlchars(&unquoted_json)) {
-        Ok(()) => (),
-        Err(err) => {
-            eprintln!("{}", err);
-            return;
-        }
-    }
-}
-
-pub fn json_convert_without_to_with_keyquotes(path: &Path) {
-        
-    let json = match load_json(path) {
-        Ok(val) => val,
-        Err(err) => {
-            eprintln!("{}", err);
-            return;
-        }
-    };
-
-    let escaped_json = json_escape_ctrlchars(&json);
-
-    match write_json(path, &json_add_key_quotes(&escaped_json)) {
-        Ok(()) => (),
-        Err(err) => {
-            eprintln!("{}", err);
-            return;
-        }
-    }
-}
-
-fn load_json(path: &Path) -> Result<String, io::Error> {
-    match fs::read_to_string(path) {
-        Ok(val) => return Ok(val),
-        Err(err) => return Err(err)
-    };
-}
-
-fn write_json(path: &Path, json: &str) -> Result<(), io::Error> {
-    match fs::write(path, json) {
-        Ok(_) => return Ok(()),
-        Err(err) => return Err(err)
-    }
-}
-
-fn json_add_key_quotes(json: &str) -> String {
-    
-    // Add quotes around all string keys:
-    let string_val_regex = Regex::new(r#"(?P<key>[A-Za-z0-9]*?)(?P<val>:\s*?"[\s\S]*?")"#).unwrap();
-    let json_string_passed = string_val_regex.replace_all(json, "\"$key\"$val");
-
-    // Add quotes around all object keys:
-    let object_val_regex = Regex::new(r"(?P<key>[A-Za-z0-9]*?)(?P<val>:\s*?[{\[])").unwrap();
-    let json_object_passed = object_val_regex.replace_all(&json_string_passed, "\"$key\"$val");
-
-    // Add quotes around all number keys:
-    let number_val_regex = Regex::new(r"(?P<before>[\[,{]\s*?)(?P<key>[A-Za-z0-9]*?)(?P<after>:\s*?[\d\-\.])").unwrap();
-    let json_number_passed = number_val_regex.replace_all(&json_object_passed, "$before\"$key\"$after");
-
-    // Add quotes around all null keys:
-    let null_val_regex = Regex::new(r"(?P<before>[\[,{]\s*?)(?P<key>[A-Za-z0-9]*?)(?P<after>:\s*?null)").unwrap();
-    let json_null_passed = null_val_regex.replace_all(&json_number_passed, "$before\"$key\"$after");
-
-    // Add quotes around all boolean-true keys:
-    let true_val_regex = Regex::new(r"(?P<before>[\[,{]\s*?)(?P<key>[A-Za-z0-9]*?)(?P<after>:\s*?true)").unwrap();
-    let json_true_passed = true_val_regex.replace_all(&json_null_passed, "$before\"$key\"$after");
-
-    // Add quotes around all boolean-false keys:
-    let false_val_regex = Regex::new(r"(?P<before>[\[,{]\s*?)(?P<key>[A-Za-z0-9]*?)(?P<after>:\s*?false)").unwrap();
-    let json_false_passed = false_val_regex.replace_all(&json_true_passed, "$before\"$key\"$after");
-
-    return json_false_passed.to_string();
-}
-
-fn json_remove_key_quotes(json: &str) -> String {
-
-    // Remove the quotes from the keys:
-    let quotes_regex = Regex::new(r#"(?P<before>[{\[,][\s]*)"(?P<key>[A-Za-z0-9]*?)"(?P<after>:)"#).unwrap();
-    let json_quotes_passed = quotes_regex.replace_all(json, "$before$key$after");
-
-    return json_quotes_passed.to_string();
-}
-
-fn json_escape_ctrlchars(json: &str) -> String {
-
-    // Replace all control characters with their escaped variants:
-
-    let mut new_json = json.to_owned();
-
-    let string_regex = Regex::new(r#""((?:[^"\\]|\\.)*)""#).unwrap();
-    for cap in string_regex.captures_iter(json) {
-        new_json = new_json.replacen(&cap[1], &cap[1].replace("\n", "\\n"), 1);
-        new_json = new_json.replacen(&cap[1], &cap[1].replace("\t", "\\t"), 1);
-    }
-    return new_json;
-}
-
-fn json_unescape_ctrlchars(json: &str) -> String {
-
-    // Replace all escaped control characters with their unescaped variants:
-
-    let mut new_json = json.to_owned();
-
-    let string_regex = Regex::new(r#""((?:[^"\\]|\\.)*)""#).unwrap();
-    for cap in string_regex.captures_iter(json) {
-        new_json = new_json.replacen(&cap[1], &cap[1].replace("\\n", "\n"), 1);
-        new_json = new_json.replacen(&cap[1], &cap[1].replace("\\t", "\t"), 1);
-    }
-    return new_json;
-}
-
-
-#[cfg(test)]
-mod tests {
-    use std::{path::Path};
-    use crate::{json_convert_without_to_with_keyquotes, load_json, json_convert_with_to_without_keyquotes};
-
-    #[test]
-    fn test_json_convert_without_to_with_keyquotes() {
-        let path = Path::new("./tmp_without_keyquotes");
-        std::fs::copy("./test_resources/Test_without_keyquotes.json", "./tmp_without_keyquotes").unwrap();
-        json_convert_without_to_with_keyquotes(path);
-        let converted_file_contents = load_json(path).unwrap();
-        let expected_file_contents = load_json(Path::new("./test_resources/Test_with_keyquotes.json")).unwrap();
-        assert!(converted_file_contents == expected_file_contents);
-        std::fs::remove_file("./tmp_without_keyquotes").unwrap();
+        self
     }
 
-    #[test]
-    fn test_json_convert_with_to_without_keyquotes() {
-        let path = Path::new("./tmp_with_keyquotes");
-        std::fs::copy("./test_resources/Test_with_keyquotes.json", "./tmp_with_keyquotes").unwrap();
-        json_convert_with_to_without_keyquotes(path);
-        let converted_file_contents = load_json(path).unwrap();
-        let expected_file_contents = load_json(Path::new("./test_resources/Test_without_keyquotes.json")).unwrap();
-        assert!(converted_file_contents == expected_file_contents);
-        std::fs::remove_file("./tmp_with_keyquotes").unwrap();
+    /// Removes key-quotes from the JSON string.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use json_keyquotes_convert::{JsonKeyQuoteConverter, Quotes};
+    /// 
+    /// let json_removed = JsonKeyQuoteConverter::new("{\"key\": \"val\"}", Quotes::default())
+    ///     .remove_key_quotes().json();
+    /// assert_eq!(json_removed, "{key: \"val\"}");
+    /// 
+    /// let json_already_removed = JsonKeyQuoteConverter::new("{key: \"val\"}", Quotes::default())
+    ///     .remove_key_quotes().json();
+    /// assert_eq!(json_already_removed, "{key: \"val\"}");
+    /// ```
+    pub fn remove_key_quotes(mut self) -> JsonKeyQuoteConverter {
+
+        self.json = json_key_quote_utils::json_remove_key_quotes(&self.json);
+
+        self
+    }
+
+    /// Escape ctrl-characters from the JSON string values
+    /// and the JSON keys with keyquotes.
+    /// 
+    /// This method will escape `newlines` and `tabs` in the JSON string values
+    /// and in the JSON keys with keyquotes.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use json_keyquotes_convert::{JsonKeyQuoteConverter, Quotes};
+    /// 
+    /// let json_escaped = JsonKeyQuoteConverter::new(r#"{"ke
+    /// y": "va
+    /// l"}"#, Quotes::default())
+    ///     .escape_ctrlchars().json();
+    /// assert_eq!(json_escaped, r#"{"ke\ny": "va\nl"}"#);
+    /// 
+    /// let json_already_escaped = JsonKeyQuoteConverter::new(r#"{"ke\ny": "va\nl"}"#, Quotes::default())
+    ///     .escape_ctrlchars().escape_ctrlchars().json();
+    /// assert_eq!(json_already_escaped, r#"{"ke\ny": "va\nl"}"#);
+    /// ```
+    pub fn escape_ctrlchars(mut self) -> JsonKeyQuoteConverter {
+
+        self.json = json_key_quote_utils::json_escape_ctrlchars(&self.json);
+
+        self
+    }
+
+    /// Unescape ctrl-characters from the JSON string values
+    /// and the JSON keys without keyquotes.
+    /// 
+    /// This method will unescape `newlines` and `tabs` in the JSON string values
+    /// and in the JSON keys without keyquotes.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use json_keyquotes_convert::{JsonKeyQuoteConverter, Quotes};
+    /// 
+    /// let json_unescaped = JsonKeyQuoteConverter::new(r#"{ke\ny: "va\nl"}"#, Quotes::default())
+    ///     .unescape_ctrlchars().json();
+    /// assert_eq!(json_unescaped, r#"{ke
+    /// y: "va
+    /// l"}"#);
+    /// 
+    /// let json_already_unescaped = JsonKeyQuoteConverter::new(r#"{ke\ny: "va\nl"}"#, Quotes::default())
+    ///     .unescape_ctrlchars().unescape_ctrlchars().json();
+    /// assert_eq!(json_already_unescaped, r#"{ke
+    /// y: "va
+    /// l"}"#);
+    /// ```
+    pub fn unescape_ctrlchars(mut self) -> JsonKeyQuoteConverter {
+
+        self.json = json_key_quote_utils::json_unescape_ctrlchars(&self.json);
+
+        self
+    }
+
+    /// Returns the JSON string.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use json_keyquotes_convert::{JsonKeyQuoteConverter, Quotes};
+    /// 
+    /// let json = JsonKeyQuoteConverter::new(r#"{"key": "value"}"#, Quotes::default())
+    ///     .json();
+    /// assert_eq!(json, r#"{"key": "value"}"#);
+    /// ```
+    pub fn json(self) -> String {
+        self.json
     }
 }

--- a/src/load_write_utils.rs
+++ b/src/load_write_utils.rs
@@ -1,0 +1,49 @@
+//! Functions used to load and write JSON to a file.
+
+use std::{path::Path, io, fs};
+
+
+/// Loads JSON from a file to a string.
+/// 
+/// # Arguments
+/// 
+/// * `path` - The file path.
+/// 
+/// # Examples
+/// 
+/// ```rust,ignore
+/// use std::path::Path;
+/// use json_keyquotes_convert::{load_write_utils};
+/// 
+/// let path = Path::new("./test_resources/Test_with_keyquotes.json");
+/// let json: String = load_write_utils::load_json(&path).expect("Couldn't load from file!");
+/// ```
+pub fn load_json(path: &Path) -> Result<String, io::Error> {
+    match fs::read_to_string(path) {
+        Ok(val) => return Ok(val),
+        Err(err) => return Err(err)
+    };
+}
+
+/// Writes JSON from a string to a file.
+/// 
+/// # Arguments
+/// 
+/// * `path` - The file path.
+/// * `json` - The JSON string to write.
+/// 
+/// # Examples
+/// 
+/// ```rust,ignore
+/// use std::path::Path;
+/// use json_keyquotes_convert::{load_write_utils};
+/// 
+/// let path = Path::new("./test_resources/Test_with_keyquotes.json");
+/// load_write_utils::write_json(&path, &json).expect("Couldn't write to file!");
+/// ```
+pub fn write_json(path: &Path, json: &str) -> Result<(), io::Error> {
+    match fs::write(path, json) {
+        Ok(_) => return Ok(()),
+        Err(err) => return Err(err)
+    }
+}


### PR DESCRIPTION
### Added
- Added documentation to [docs.rs](https://docs.rs/json_keyquotes_convert).
- Added more tests to improve the coverage.
- Use Rust modules to divide the functionality.
- Made the core functions public.
- Applied the Builder Pattern for `JsonKeyQuoteConverter` (usage of this is now recommended over calling the core functions).

### Changed
- Greatly improved the README of the crate.
- Lots of improvements and bugfixes for the core functions.
- Improved the release pipeline to only push a new version to Crates.io when it is newer than the current published version.