### PR TITLE
`Fix` | Fix carriage return escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2023-08-17
+### Changed
+- Updated some outdated docs comments in the code.
+### Fixed
+- Fixed an issue with \r characters not getting escaped correctly
+
 ## [0.2.2] - 2023-08-17
 ### Changed
 - Fixed errors in the README of the crate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "json_keyquotes_convert"
 description = "A Rust library crate to convert JSON from and to JSON without key-quotes."
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Andreas02-dev/json_keyquotes_convert_rs/"

--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ let json_escaped = json_key_quote_utils::json_escape_ctrlchars(&json_added);
   - Supports control character escaping in JSON string values:
 	- Newline (\n): :heavy_check_mark: :white_check_mark:
 	- Tab (\t): :heavy_check_mark: :white_check_mark:
+	- Carriage return (\r): :heavy_check_mark: :white_check_mark:
   - Supports control character unescaping in JSON string values:
 	- Newline (\n): :heavy_check_mark: :white_check_mark:
 	- Tab (\t): :heavy_check_mark: :white_check_mark:
+	- Carriage return (\r): :heavy_check_mark: :white_check_mark:
   - Supported :heavy_check_mark: characters in JSON keys:
 	- [A-Z] [a-z] [0-9] \` ~ ! @ # $ % € ^ & * ( ) - _ = + \ | ; " ' . < > / ? \r \n \t \f \v `<U+0020>(Space)`
 	- Note: ' and " and their escaped variants could be misinterpreted as keyquotes when used as the last character in a JSON key. It is therefore not recommended to start or end a JSON key with these characters.

--- a/src/json_key_quote_utils.rs
+++ b/src/json_key_quote_utils.rs
@@ -231,8 +231,8 @@ pub fn json_remove_key_quotes(json: &str) -> String {
 /// Escape ctrl-characters from the JSON string values
 /// and remove ctrl-characters from the JSON keys with keyquotes.
 ///
-/// This method will escape `newlines` and `tabs` in the JSON string values
-/// and remove `newlines` and `tabs` in the JSON keys with keyquotes.
+/// This method will escape `newlines`, `tabs` and `carriage returns` in the JSON string values
+/// and remove `newlines`, `tabs` and `carriage returns` in the JSON keys with keyquotes.
 ///
 /// # Arguments
 ///

--- a/src/json_key_quote_utils.rs
+++ b/src/json_key_quote_utils.rs
@@ -270,6 +270,7 @@ pub fn json_escape_ctrlchars(json: &str) -> String {
         for cap in singlequoted_string_key_regex.captures_iter(&new_json.clone()) {
             let cap_match = cap.name("key").unwrap().as_str();
             new_json = new_json.replacen(cap_match, &cap_match.replace("\n", ""), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\r", ""), 1);
             new_json =
                 new_json.replacen(cap_match, &cap_match.replace("\t", "").replace("\t", ""), 1);
         }
@@ -286,6 +287,7 @@ pub fn json_escape_ctrlchars(json: &str) -> String {
         for cap in singlequoted_string_key_regex.captures_iter(&new_json.clone()) {
             let cap_match = cap.name("key").unwrap().as_str();
             new_json = new_json.replacen(cap_match, &cap_match.replace("\n", ""), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\r", ""), 1);
             new_json =
                 new_json.replacen(cap_match, &cap_match.replace("\t", "").replace("\t", ""), 1);
         }
@@ -302,6 +304,7 @@ pub fn json_escape_ctrlchars(json: &str) -> String {
         for cap in doublequoted_string_key_regex.captures_iter(&new_json.clone()) {
             let cap_match = cap.name("key").unwrap().as_str();
             new_json = new_json.replacen(cap_match, &cap_match.replace("\n", ""), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\r", ""), 1);
             new_json =
                 new_json.replacen(cap_match, &cap_match.replace("\t", "").replace("\t", ""), 1);
         }
@@ -318,6 +321,7 @@ pub fn json_escape_ctrlchars(json: &str) -> String {
         for cap in doublequoted_string_key_regex.captures_iter(&new_json.clone()) {
             let cap_match = cap.name("key").unwrap().as_str();
             new_json = new_json.replacen(cap_match, &cap_match.replace("\n", ""), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\r", ""), 1);
             new_json =
                 new_json.replacen(cap_match, &cap_match.replace("\t", "").replace("\t", ""), 1);
             new_json =
@@ -336,6 +340,7 @@ pub fn json_escape_ctrlchars(json: &str) -> String {
         for cap in object_key_regex.captures_iter(&new_json.clone()) {
             let cap_match = cap.name("key").unwrap().as_str();
             new_json = new_json.replacen(cap_match, &cap_match.replace("\n", ""), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\r", ""), 1);
             new_json =
                 new_json.replacen(cap_match, &cap_match.replace("\t", "").replace("\t", ""), 1);
         }
@@ -352,6 +357,7 @@ pub fn json_escape_ctrlchars(json: &str) -> String {
         for cap in object_key_regex.captures_iter(&new_json.clone()) {
             let cap_match = cap.name("key").unwrap().as_str();
             new_json = new_json.replacen(cap_match, &cap_match.replace("\n", ""), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\r", ""), 1);
             new_json =
                 new_json.replacen(cap_match, &cap_match.replace("\t", "").replace("\t", ""), 1);
         }
@@ -368,6 +374,7 @@ pub fn json_escape_ctrlchars(json: &str) -> String {
         for cap in number_key_regex.captures_iter(&new_json.clone()) {
             let cap_match = cap.name("key").unwrap().as_str();
             new_json = new_json.replacen(cap_match, &cap_match.replace("\n", ""), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\r", ""), 1);
             new_json =
                 new_json.replacen(cap_match, &cap_match.replace("\t", "").replace("\t", ""), 1);
         }
@@ -384,6 +391,7 @@ pub fn json_escape_ctrlchars(json: &str) -> String {
         for cap in number_key_regex.captures_iter(&new_json.clone()) {
             let cap_match = cap.name("key").unwrap().as_str();
             new_json = new_json.replacen(cap_match, &cap_match.replace("\n", ""), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\r", ""), 1);
             new_json =
                 new_json.replacen(cap_match, &cap_match.replace("\t", "").replace("\t", ""), 1);
         }
@@ -400,6 +408,7 @@ pub fn json_escape_ctrlchars(json: &str) -> String {
         for cap in null_boolean_key_regex.captures_iter(&new_json.clone()) {
             let cap_match = cap.name("key").unwrap().as_str();
             new_json = new_json.replacen(cap_match, &cap_match.replace("\n", ""), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\r", ""), 1);
             new_json =
                 new_json.replacen(cap_match, &cap_match.replace("\t", "").replace("\t", ""), 1);
         }
@@ -416,6 +425,7 @@ pub fn json_escape_ctrlchars(json: &str) -> String {
         for cap in null_boolean_key_regex.captures_iter(&new_json.clone()) {
             let cap_match = cap.name("key").unwrap().as_str();
             new_json = new_json.replacen(cap_match, &cap_match.replace("\n", ""), 1);
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\r", ""), 1);
             new_json =
                 new_json.replacen(cap_match, &cap_match.replace("\t", "").replace("\t", ""), 1);
         }
@@ -424,6 +434,7 @@ pub fn json_escape_ctrlchars(json: &str) -> String {
         let singlequoted_string_value_regex =
             Lazy::new(|| Regex::new(r#":[\s]*?'((?:[^'\\]|\\.)*)'"#).unwrap());
         for cap in singlequoted_string_value_regex.captures_iter(&new_json.clone()) {
+            new_json = new_json.replacen(&cap[1], &cap[1].replace("\r", "\\r"), 1);
             new_json = new_json.replacen(&cap[1], &cap[1].replace("\n", "\\n"), 1);
             new_json = new_json.replacen(&cap[1], &cap[1].replace("\t", "\\t"), 1);
         }
@@ -432,6 +443,7 @@ pub fn json_escape_ctrlchars(json: &str) -> String {
         let doublequoted_string_value_regex =
             Lazy::new(|| Regex::new(r#":[\s]*?"((?:[^"\\]|\\.)*)""#).unwrap());
         for cap in doublequoted_string_value_regex.captures_iter(&new_json.clone()) {
+            new_json = new_json.replacen(&cap[1], &cap[1].replace("\r", "\\r"), 1);
             new_json = new_json.replacen(&cap[1], &cap[1].replace("\n", "\\n"), 1);
             new_json = new_json.replacen(&cap[1], &cap[1].replace("\t", "\\t"), 1);
         }
@@ -443,8 +455,8 @@ pub fn json_escape_ctrlchars(json: &str) -> String {
 /// Unescape ctrl-characters from the JSON string values
 /// and remove ctrl-characters from the JSON keys without keyquotes.
 ///
-/// This method will unescape `newlines` and `tabs` in the JSON string values
-/// and remove `newlines` and `tabs` in the JSON keys without keyquotes.
+/// This method will unescape `newlines`, `tabs` and `carriage returns` in the JSON string values
+/// and remove `newlines`, `tabs` and `carriage returns` in the JSON keys without keyquotes.
 ///
 /// # Arguments
 ///
@@ -482,6 +494,7 @@ pub fn json_unescape_ctrlchars(json: &str) -> String {
         });
         for cap in singlequoted_string_key_regex.captures_iter(&new_json.clone()) {
             let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\\r", ""), 1);
             new_json = new_json.replacen(cap_match, &cap_match.replace("\\n", ""), 1);
             new_json = new_json.replacen(cap_match, &cap_match.replace("\\t", ""), 1);
         }
@@ -497,6 +510,7 @@ pub fn json_unescape_ctrlchars(json: &str) -> String {
         });
         for cap in doublequoted_string_key_regex.captures_iter(&new_json.clone()) {
             let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\\r", ""), 1);
             new_json = new_json.replacen(cap_match, &cap_match.replace("\\n", ""), 1);
             new_json = new_json.replacen(cap_match, &cap_match.replace("\\t", ""), 1);
         }
@@ -512,6 +526,7 @@ pub fn json_unescape_ctrlchars(json: &str) -> String {
         });
         for cap in object_key_regex.captures_iter(&new_json.clone()) {
             let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\\r", ""), 1);
             new_json = new_json.replacen(cap_match, &cap_match.replace("\\n", ""), 1);
             new_json = new_json.replacen(cap_match, &cap_match.replace("\\t", ""), 1);
         }
@@ -527,6 +542,7 @@ pub fn json_unescape_ctrlchars(json: &str) -> String {
         });
         for cap in number_key_regex.captures_iter(&new_json.clone()) {
             let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\\r", ""), 1);
             new_json = new_json.replacen(cap_match, &cap_match.replace("\\n", ""), 1);
             new_json = new_json.replacen(cap_match, &cap_match.replace("\\t", ""), 1);
         }
@@ -542,6 +558,7 @@ pub fn json_unescape_ctrlchars(json: &str) -> String {
         });
         for cap in null_boolean_key_regex.captures_iter(&new_json.clone()) {
             let cap_match = cap.name("key").unwrap().as_str();
+            new_json = new_json.replacen(cap_match, &cap_match.replace("\\r", ""), 1);
             new_json = new_json.replacen(cap_match, &cap_match.replace("\\n", ""), 1);
             new_json = new_json.replacen(cap_match, &cap_match.replace("\\t", ""), 1);
         }
@@ -550,6 +567,7 @@ pub fn json_unescape_ctrlchars(json: &str) -> String {
         let singlequoted_string_value_regex =
             Lazy::new(|| Regex::new(r#":[\s]*?'((?:[^'\\]|\\.)*)'"#).unwrap());
         for cap in singlequoted_string_value_regex.captures_iter(&new_json.clone()) {
+            new_json = new_json.replacen(&cap[1], &cap[1].replace("\\r", "\r"), 1);
             new_json = new_json.replacen(&cap[1], &cap[1].replace("\\n", "\n"), 1);
             new_json = new_json.replacen(&cap[1], &cap[1].replace("\\t", "\t"), 1);
         }
@@ -558,6 +576,7 @@ pub fn json_unescape_ctrlchars(json: &str) -> String {
         let doublequoted_string_value_regex =
             Lazy::new(|| Regex::new(r#":[\s]*?"((?:[^"\\]|\\.)*)""#).unwrap());
         for cap in doublequoted_string_value_regex.captures_iter(&new_json.clone()) {
+            new_json = new_json.replacen(&cap[1], &cap[1].replace("\\r", "\r"), 1);
             new_json = new_json.replacen(&cap[1], &cap[1].replace("\\n", "\n"), 1);
             new_json = new_json.replacen(&cap[1], &cap[1].replace("\\t", "\t"), 1);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,8 +109,8 @@ impl JsonKeyQuoteConverter {
     /// Escape ctrl-characters from the JSON string values
     /// and remove ctrl-characters from the JSON keys with keyquotes.
     ///
-    /// This method will escape `newlines` and `tabs` in the JSON string values
-    /// and remove `newlines` and `tabs` in the JSON keys with keyquotes.
+    /// This method will escape `newlines`, `tabs` and `carriage returns` in the JSON string values
+    /// and remove `newlines`, `tabs` and `carriage returns` in the JSON keys with keyquotes.
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,10 +107,10 @@ impl JsonKeyQuoteConverter {
     }
 
     /// Escape ctrl-characters from the JSON string values
-    /// and the JSON keys with keyquotes.
+    /// and remove ctrl-characters from the JSON keys with keyquotes.
     ///
     /// This method will escape `newlines` and `tabs` in the JSON string values
-    /// and in the JSON keys with keyquotes.
+    /// and remove `newlines` and `tabs` in the JSON keys with keyquotes.
     ///
     /// # Examples
     ///
@@ -133,10 +133,10 @@ impl JsonKeyQuoteConverter {
     }
 
     /// Unescape ctrl-characters from the JSON string values
-    /// and the JSON keys without keyquotes.
+    /// and remove ctrl-characters from the JSON keys without keyquotes.
     ///
-    /// This method will unescape `newlines` and `tabs` in the JSON string values
-    /// and in the JSON keys without keyquotes.
+    /// This method will unescape `newlines`, `tabs` and `carriage returns` in the JSON string values
+    /// and remove `newlines`, `tabs` and `carriage returns` in the JSON keys without keyquotes.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
### Changed
- Updated some outdated docs comments in the code.
### Fixed
- Fixed an issue with \r characters not getting escaped correctly